### PR TITLE
Support for connection as NPC

### DIFF
--- a/client/bin/RakSAMPClient.xml
+++ b/client/bin/RakSAMPClient.xml
@@ -11,7 +11,7 @@ Avalable runmodes:
 <RakSAMPClient console="0" runmode="3" autorun="0" find="1" select_classid="0" manual_spawn="1"
 			   print_timestamps="0" chatcolor_rgb="0 0 130" clientmsg_rgb="0 130 0" cpalert_rgb="170 0 0"
 			   followplayer="P3ti" followplayerwithvehicleid="295" followXOffset="3.0" followYOffset="0.0" followZOffset="0.0"
-			   updatestats="1" minfps="20" maxfps="90" clientversion="0.3.7">
+			   updatestats="1" minfps="20" maxfps="90" clientversion="0.3.7" npc="0">
 
 	<server nickname="root" password="">127.0.0.1:7777</server>
 

--- a/client/src/xmlsets.cpp
+++ b/client/src/xmlsets.cpp
@@ -52,6 +52,9 @@ int LoadSettings()
 		// get client version
 		strcpy(settings.szClientVersion, (char *)rakSAMPElement->Attribute("clientversion"));
 
+		// npc mode
+		rakSAMPElement->QueryIntAttribute("npc", (int *)&settings.iNPC);
+
 		// get chat color
 		rakSAMPElement->QueryColorAttribute("chatcolor_rgb",
 			(unsigned char *)&settings.bChatColorRed, (unsigned char *)&settings.bChatColorGreen, (unsigned char *)&settings.bChatColorBlue);

--- a/client/src/xmlsets.h
+++ b/client/src/xmlsets.h
@@ -69,6 +69,8 @@ struct stSettings
 
 	char szClientVersion[20];
 
+	int iNPC;
+
 	bool bSpam;
 	bool bFakeKill;
 	bool bLag;


### PR DESCRIPTION
- Adds an XML value to store the NPC setting
- Changes Auth Key content to "NPC" (expected by SAMP Server) when iNPC mode is true
- Sends RPC_NPCJoin with different Bitstream contents when iNPC is true